### PR TITLE
Bug fix for Remove and add tests

### DIFF
--- a/avltree.go
+++ b/avltree.go
@@ -14,11 +14,11 @@ func (t *AVLTree) Add(key int, value int) {
 }
 
 func (t *AVLTree) Remove(key int) {
-	t.root.remove(key)
+	t.root = t.root.remove(key)
 }
 
 func (t *AVLTree) Update(oldKey int, newKey int, newValue int) {
-	t.root.remove(oldKey)
+	t.root = t.root.remove(oldKey)
 	t.root = t.root.add(newKey, newValue)
 }
 

--- a/avltree_test.go
+++ b/avltree_test.go
@@ -1,0 +1,46 @@
+package avltree
+
+import (
+	"math/rand"
+	"testing"
+)
+
+const (
+	opAdd = iota
+	opRemove
+	opSearch
+)
+
+func TestTree(t *testing.T) {
+	tree := &AVLTree{}
+	m := make(map[int]int)
+
+	const maxKey = 100
+	const nops = 10000
+	for i := 0; i < nops; i++ {
+		op := rand.Intn(3)
+		k := rand.Intn(maxKey)
+
+		switch op {
+		case opAdd:
+			v := rand.Int()
+			tree.Add(k, v)
+			m[k] = v
+		case opRemove:
+			tree.Remove(k)
+			delete(m, k)
+		case opSearch:
+			var tv int
+			node := tree.Search(k)
+			tok := node != nil
+			if tok {
+				tv = node.Value
+			}
+
+			mv := m[k]
+			if tv != mv {
+				t.Errorf("Incorrect value for key %d, want: %d, got: %d", k, mv, tv)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes a bug with `Remove` caused by `t.root` not being assigned to the returned value (in the case where the only node in a tree is removed from the tree).

This PR also adds a small but fairly comprehensive test.